### PR TITLE
Add installation instructions for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,33 @@ docker build -t gpg-tui .
 docker run -it gpg-tui
 ```
 
+### FreeBSD
+
+All required dependencies are automatically fetched and installed independently of the installation method chosen.
+
+#### Building from source
+
+```sh
+# using a port
+cd /usr/ports/security/gpg-tui
+make install
+```
+
+```sh
+# alternative method using portmaster
+portmaster security/gpg-tui
+```
+
+#### Binary releases
+
+```sh
+# update repository catalogue (if outdated)
+pkg update
+
+# fetch and install the package
+pkg install gpg-tui
+```
+
 ### Manually
 
 #### Building from source
@@ -259,7 +286,7 @@ The level of detail that an individual table row shows is determined by [detail 
 ```
 [sc--] rsa3072/B14085A20355B74DE0CE0FA1E19F76D037BD65B6  │  [u] Example Key <example@key>
 |      └─(2021-05-14)                                    │   └─[u] Other User ID <example@key>
-[--e-] rsa3072/E56CAC142AE5A979BEECB00FB4F68595CAD4E7E5  │ 
+[--e-] rsa3072/E56CAC142AE5A979BEECB00FB4F68595CAD4E7E5  │
        └─(2021-05-14)
 ```
 
@@ -447,7 +474,7 @@ Also you can switch between command mode and search by pressing `Tab`.
 
 #### List
 
-Available keys in the keyring are listed on a table as default. They can be [scrolled](#scrolling) or the listing type (public/secret keys) can be changed by changing the tab via arrow keys. 
+Available keys in the keyring are listed on a table as default. They can be [scrolled](#scrolling) or the listing type (public/secret keys) can be changed by changing the tab via arrow keys.
 
 See the [approach](#approach) section for more information about the meaning of the table rows.
 
@@ -513,7 +540,7 @@ Press `Backspace` followed by `y` (for confirmation) to delete the selected key 
 
 Press `Ctrl-y` for refreshing the keyring.
 
-This feature uses `gpg` fallback and runs `gpg --refresh-keys` command. 
+This feature uses `gpg` fallback and runs `gpg --refresh-keys` command.
 
 ![](demo/gpg-tui-refresh_keys.gif)
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ The level of detail that an individual table row shows is determined by [detail 
 ```
 [sc--] rsa3072/B14085A20355B74DE0CE0FA1E19F76D037BD65B6  │  [u] Example Key <example@key>
 |      └─(2021-05-14)                                    │   └─[u] Other User ID <example@key>
-[--e-] rsa3072/E56CAC142AE5A979BEECB00FB4F68595CAD4E7E5  │
+[--e-] rsa3072/E56CAC142AE5A979BEECB00FB4F68595CAD4E7E5  │ 
        └─(2021-05-14)
 ```
 
@@ -474,7 +474,7 @@ Also you can switch between command mode and search by pressing `Tab`.
 
 #### List
 
-Available keys in the keyring are listed on a table as default. They can be [scrolled](#scrolling) or the listing type (public/secret keys) can be changed by changing the tab via arrow keys.
+Available keys in the keyring are listed on a table as default. They can be [scrolled](#scrolling) or the listing type (public/secret keys) can be changed by changing the tab via arrow keys. 
 
 See the [approach](#approach) section for more information about the meaning of the table rows.
 
@@ -540,7 +540,7 @@ Press `Backspace` followed by `y` (for confirmation) to delete the selected key 
 
 Press `Ctrl-y` for refreshing the keyring.
 
-This feature uses `gpg` fallback and runs `gpg --refresh-keys` command.
+This feature uses `gpg` fallback and runs `gpg --refresh-keys` command. 
 
 ![](demo/gpg-tui-refresh_keys.gif)
 


### PR DESCRIPTION
## Description
Add installation instructions for FreeBSD to the README file.

## Motivation and Context
A FreeBSD port has been created to let FreeBSD users automatically fetch and install all dependencies and the sources of this software.
The port will be found by the automatic package builders and binary packages for all supported architectures and FreeBSD releases will appear within a few days.

## How Has This Been Tested?
Text change, checked with a Markdown viewer for correct rendering.
(The program has been built on 32 and 64 bit architectures on several FreeBSD releases and has been tested on amd64.
But this pull request does only cover the installation description for FreeBSD.)

## Output (if appropriate):
Rendered Markdown will contain the added section.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.