### PR TITLE
README Debian needs  `libxkbcommon-dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Pleases note that the name of these dependencies (packages) might change dependi
 For installing these dependencies:
 
 - on Arch Linux, run `pacman -S gpgme libx11`
-- on Debian/Ubuntu, run `apt-get install libgpgme-dev libx11-dev libxcb-shape0-dev libxcb-xfixes0-dev`
+- on Debian/Ubuntu, run `apt-get install libgpgme-dev libx11-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev`
 - on Fedora, run `dnf install gpgme-devel libX11-devel`
 - on Void Linux, run `xbps-install -S gpgme-devel libxcb-devel libgpg-error-devel gnupg`
 


### PR DESCRIPTION
## Description
On debian/Ubuntu `libxkbcommon-dev` needs to be present to be able to build from source.

## Motivation and Context
Help others build from source

## How Has This Been Tested?
````bash
$ cargo install --root "$HOME/.cargo" --path .
....
error: linking with `cc` failed: exit status: 1
note: /usr/bin/ld: cannot find -lxkbcommon

$ sudo apt install libxkbcommon-dev

$ cargo install --root "$HOME/.cargo" --path .
  Installing gpg-tui v0.7.0 ($HOME/Dokumenter/git-workfolder/gpg-tui)
    Updating crates.io index
   Compiling gpg-tui v0.7.0 $HOME/Dokumenter/git-workfolder/gpg-tui)
    Finished release [optimized] target(s) in 22.16s
  Installing $HOME/.cargo/bin/completions
  Installing $HOME/.cargo/bin/gpg-tui
   Installed package `gpg-tui v0.7.0 ($HOME/Dokumenter/git-workfolder/gpg-tui)` (executables `completions`, `gpg-tui`)

````

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
