### PR TITLE
chore: Update the edition of Rust to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/orhun/gpg-tui"
 keywords = ["gnupg", "gpg", "tui", "key", "management"]
 categories = ["command-line-utilities"]
 include = ["src/**/*", "assets/*", "Cargo.*", "LICENSE", "README.md", "CHANGELOG.md"]
-edition = "2018"
+edition = "2021"
 default-run = "gpg-tui"
 
 [[bin]]


### PR DESCRIPTION
## Description
This PR updates the edition of `Rust` to 2021 version by following the the official [guidelines](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html).

## Motivation and Context
Resolves #36

## How Has This Been Tested?
I have run `cargo build` and `cargo test` with success. Furthermore, I manually tested the binary itself and everything seems to be in order.

## Output (if appropriate):
None of the source code files have changed since migration, though the proof that the migration did indeed happen can be seen if we re-run `cargo fix --edition`:

```sh
warning: `src/lib.rs` is already on the latest edition (2021), unable to migrate further
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
