### PR TITLE
chore: Switch to `ratatui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,22 +254,6 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f67c7faacd4db07a939f55d66a983a5355358a1f17d32cc9a8d01d1266b9ce"
@@ -513,18 +497,18 @@ dependencies = [
  "clap_complete",
  "colorsys",
  "copypasta-ext",
- "crossterm 0.26.0",
+ "crossterm",
  "dirs-next",
  "gpgme",
  "hex-literal",
  "image",
  "pretty_assertions",
+ "ratatui",
  "rust-embed",
  "serde",
  "shellexpand",
  "tinytemplate",
  "toml 0.7.2",
- "tui",
  "unicode-width",
 ]
 
@@ -1003,6 +987,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc0d032bccba900ee32151ec0265667535c230169f5a011154cdcd984e16829"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,19 +1370,6 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
-]
-
-[[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags",
- "cassowary",
- "crossterm 0.25.0",
- "unicode-segmentation",
- "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ gpg-tests = []
 
 [dependencies]
 gpgme = "0.11.0"
-tui = "0.19.0"
+tui = { package = "ratatui", version = "0.20.1" }
 anyhow = "1.0.69"
 chrono = "0.4.23"
 unicode-width = "0.1.10"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Updated Cargo.{toml,lock} according to the [instructions](https://github.com/tui-rs-revival/ratatui/#install) to use `ratatui` instead of `tui`.

## Motivation and Context
Resolves #54 

## How Has This Been Tested?
- Run `docker build -t gpg-tui .` to build the image
- Run `docker run -it gpg-tui` to test the application
- Surface test of the UI by creating a key
- Run **Build & Test** job locally

## Output (if appropriate):
<!--- What is the expected output of the project after these changes? -->
<!--- You might use logs, screenshots or files depending on the behaviour. --->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other — dependency replacement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
