### PR TITLE
chore: Upgrade clap from v3 to v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,21 +12,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -123,52 +161,55 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
- "atty",
- "bitflags",
+ "clap_builder",
  "clap_derive",
- "clap_lex",
- "indexmap",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
  "strsim",
- "termcolor",
  "terminal_size",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.2.5"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+checksum = "1594fe2312ec4abf402076e407628f5c313e54c32ade058521df4ee34ecac8a8"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "clipboard-win"
@@ -195,6 +236,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colorsys"
@@ -401,7 +448,7 @@ checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
 dependencies = [
  "libc",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -445,6 +492,17 @@ dependencies = [
  "errno-dragonfly",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -568,15 +626,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -641,9 +690,21 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix 0.37.7",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -722,6 +783,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,7 +864,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -888,12 +955,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
-
-[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,7 +983,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -941,30 +1002,6 @@ dependencies = [
  "diff",
  "output_vt100",
  "yansi",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -1059,11 +1096,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.7",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1285,17 +1336,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c9afddd2cec1c0909f06b00ef33f94ab2cc0578c4a610aa208ddfec8aa2b43a"
 dependencies = [
- "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-dependencies = [
- "terminal_size",
+ "rustix 0.36.11",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1396,6 +1438,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version-compare"
@@ -1615,7 +1663,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -1624,7 +1672,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1633,13 +1690,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1649,10 +1721,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1661,10 +1745,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1673,16 +1769,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ shellexpand = "3.1.0"
 hex-literal = "0.3.4"
 toml = "0.7.3"
 dirs-next = "2.0.0"
-clap_complete = "3.2.5"
+clap_complete = "4.2.3"
 tinytemplate = "1.2.1"
 
 [dependencies.crossterm]
@@ -45,7 +45,7 @@ version = "0.26.1"
 features = ["serde"]
 
 [dependencies.clap]
-version = "3.2.23"
+version = "4.2.7"
 features = ["derive", "env", "wrap_help"]
 
 [dependencies.image]

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -4,9 +4,9 @@ use crate::app::selection::Selection;
 use crate::app::style::Style;
 use crate::gpg::key::KeyType;
 use crate::widget::row::ScrollDirection;
+use clap::ValueEnum;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
-use clap::ValueEnum;
 
 /// Command to run on rendering process.
 ///
@@ -176,8 +176,11 @@ impl FromStr for Command {
 			}))),
 			"help" | "h" => Ok(Command::ShowHelp),
 			"style" => Ok(Command::ChangeStyle(
-				Style::from_str(&args.first().cloned().unwrap_or_default(), true)
-					.unwrap_or_default(),
+				Style::from_str(
+					&args.first().cloned().unwrap_or_default(),
+					true,
+				)
+				.unwrap_or_default(),
 			)),
 			"output" | "out" => {
 				if !args.is_empty() {

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -6,6 +6,7 @@ use crate::gpg::key::KeyType;
 use crate::widget::row::ScrollDirection;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
+use clap::ValueEnum;
 
 /// Command to run on rendering process.
 ///
@@ -175,7 +176,7 @@ impl FromStr for Command {
 			}))),
 			"help" | "h" => Ok(Command::ShowHelp),
 			"style" => Ok(Command::ChangeStyle(
-				Style::from_str(&args.first().cloned().unwrap_or_default())
+				Style::from_str(&args.first().cloned().unwrap_or_default(), true)
 					.unwrap_or_default(),
 			)),
 			"output" | "out" => {
@@ -248,7 +249,7 @@ impl FromStr for Command {
 			"copy" | "c" => {
 				if let Some(arg) = args.first().cloned() {
 					Ok(Command::Copy(
-						Selection::from_str(&arg).map_err(|_| ())?,
+						Selection::from_str(&arg, true).map_err(|_| ())?,
 					))
 				} else {
 					Ok(Command::SwitchMode(Mode::Copy))

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -257,7 +257,7 @@ fn handle_key_event(
 			}
 			Key::Char('1') => {
 				if app.mode == Mode::Copy {
-					Command::Copy(Selection::TableRow(1))
+					Command::Copy(Selection::Row1)
 				} else {
 					Command::Set(
 						String::from("detail"),
@@ -267,7 +267,7 @@ fn handle_key_event(
 			}
 			Key::Char('2') => {
 				if app.mode == Mode::Copy {
-					Command::Copy(Selection::TableRow(2))
+					Command::Copy(Selection::Row2)
 				} else {
 					Command::Set(
 						String::from("detail"),

--- a/src/app/launcher.rs
+++ b/src/app/launcher.rs
@@ -14,7 +14,7 @@ use crate::widget::list::StatefulList;
 use crate::widget::row::ScrollDirection;
 use crate::widget::style::Color as WidgetColor;
 use crate::widget::table::{StatefulTable, TableSize, TableState};
-use anyhow::{anyhow, Error as AnyhowError, Result};
+use anyhow::{Error as AnyhowError, Result};
 use colorsys::Rgb;
 use copypasta_ext::display::DisplayServer as ClipboardDisplayServer;
 use copypasta_ext::ClipboardProviderExt;
@@ -24,6 +24,7 @@ use std::process::Command as OsCommand;
 use std::str;
 use std::str::FromStr;
 use std::time::Instant;
+use clap::ValueEnum;
 use tui::style::Color;
 
 /// Max duration of prompt messages.
@@ -243,8 +244,8 @@ impl<'a> App<'a> {
 								Command::Copy(Selection::KeyId),
 								Command::Copy(Selection::KeyFingerprint),
 								Command::Copy(Selection::KeyUserId),
-								Command::Copy(Selection::TableRow(1)),
-								Command::Copy(Selection::TableRow(2)),
+								Command::Copy(Selection::Row1),
+								Command::Copy(Selection::Row2),
 								Command::Paste,
 								Command::ToggleDetail(false),
 								Command::ToggleDetail(true),
@@ -669,7 +670,7 @@ impl<'a> App<'a> {
 						}
 						"detail" => {
 							if let Ok(detail_level) =
-								KeyDetail::from_str(&value)
+								KeyDetail::from_str(&value, true)
 							{
 								if let Some(index) =
 									self.keys_table.state.tui.selected()
@@ -713,7 +714,7 @@ impl<'a> App<'a> {
 								),
 							)
 						}
-						"style" => match Style::from_str(&value) {
+						"style" => match Style::from_str(&value, true) {
 							Ok(style) => {
 								self.state.style = style;
 								(
@@ -851,20 +852,17 @@ impl<'a> App<'a> {
 				let selected_key =
 					&self.keys_table.selected().expect("invalid selection");
 				let content = match copy_type {
-					Selection::TableRow(1) => Ok(selected_key
+					Selection::Row1 => Ok(selected_key
 						.get_subkey_info(
 							self.gpgme.config.default_key.as_deref(),
 							self.keys_table.state.size != TableSize::Normal,
 						)
 						.join("\n")),
-					Selection::TableRow(2) => Ok(selected_key
+					Selection::Row2 => Ok(selected_key
 						.get_user_info(
 							self.keys_table.state.size == TableSize::Minimized,
 						)
 						.join("\n")),
-					Selection::TableRow(_) => {
-						Err(anyhow!("invalid row number"))
-					}
 					Selection::Key => {
 						match self.gpgme.get_exported_keys(
 							match self.tab {

--- a/src/app/launcher.rs
+++ b/src/app/launcher.rs
@@ -15,6 +15,7 @@ use crate::widget::row::ScrollDirection;
 use crate::widget::style::Color as WidgetColor;
 use crate::widget::table::{StatefulTable, TableSize, TableState};
 use anyhow::{Error as AnyhowError, Result};
+use clap::ValueEnum;
 use colorsys::Rgb;
 use copypasta_ext::display::DisplayServer as ClipboardDisplayServer;
 use copypasta_ext::ClipboardProviderExt;
@@ -24,7 +25,6 @@ use std::process::Command as OsCommand;
 use std::str;
 use std::str::FromStr;
 use std::time::Instant;
-use clap::ValueEnum;
 use tui::style::Color;
 
 /// Max duration of prompt messages.

--- a/src/app/selection.rs
+++ b/src/app/selection.rs
@@ -16,7 +16,7 @@ pub enum Selection {
 	#[clap(aliases = ["id", "key_id", "keyid"])]
 	KeyId,
 	/// Fingerprint of the selected key.
-	#[clap(aliases = ["fingerprint", "key_fingerprint", "keyfingerprint", "fpr"])]
+	#[clap(aliases = ["fingerprint", "key_fingerprint", "keyfingerprint", "fpr", "key_fpr", "keyfpr"])]
 	KeyFingerprint,
 	/// User ID of the selected key.
 	#[clap(aliases = ["user", "user_id", "userid", "user-id", "key_user_id", "keyuserid"])]

--- a/src/app/selection.rs
+++ b/src/app/selection.rs
@@ -1,5 +1,5 @@
-use std::fmt::{Display, Formatter, Result as FmtResult};
 use clap::ValueEnum;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// Application property to copy to clipboard.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
@@ -39,8 +39,6 @@ impl Display for Selection {
 		)
 	}
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/src/app/selection.rs
+++ b/src/app/selection.rs
@@ -1,18 +1,25 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::str::FromStr;
+use clap::ValueEnum;
 
 /// Application property to copy to clipboard.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum Selection {
-	/// Selected row of the keys table.
-	TableRow(usize),
+	/// One of the selected rows of the keys table
+	#[clap(aliases = ["row_1", "row1", "1"])]
+	Row1,
+	/// The other selected row of the keys table
+	#[clap(aliases = ["row_2", "row2", "2"])]
+	Row2,
 	/// Exported key.
 	Key,
 	/// ID of the selected key.
+	#[clap(aliases = ["id", "key_id", "keyid"])]
 	KeyId,
 	/// Fingerprint of the selected key.
+	#[clap(aliases = ["fingerprint", "key_fingerprint", "keyfingerprint", "fpr"])]
 	KeyFingerprint,
 	/// User ID of the selected key.
+	#[clap(aliases = ["user", "user_id", "userid", "user-id", "key_user_id", "keyuserid"])]
 	KeyUserId,
 }
 
@@ -22,7 +29,8 @@ impl Display for Selection {
 			f,
 			"{}",
 			match self {
-				Self::TableRow(i) => format!("table row ({i})"),
+				Self::Row1 => "table row (1)".to_string(),
+				Self::Row2 => "table row (2)".to_string(),
 				Self::Key => String::from("exported key"),
 				Self::KeyId => String::from("key ID"),
 				Self::KeyFingerprint => String::from("key fingerprint"),
@@ -32,22 +40,7 @@ impl Display for Selection {
 	}
 }
 
-impl FromStr for Selection {
-	type Err = String;
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		match s {
-			"row1" | "1" => Ok(Self::TableRow(1)),
-			"row2" | "2" => Ok(Self::TableRow(2)),
-			"key" => Ok(Self::Key),
-			"key_id" | "id" => Ok(Self::KeyId),
-			"key_fingerprint" | "key_fpr" | "fingerprint" | "fpr" => {
-				Ok(Self::KeyFingerprint)
-			}
-			"key_user_id" | "user" | "user_id" => Ok(Self::KeyUserId),
-			_ => Err(String::from("could not parse the type")),
-		}
-	}
-}
+
 
 #[cfg(test)]
 mod tests {
@@ -55,19 +48,22 @@ mod tests {
 	use pretty_assertions::assert_eq;
 	#[test]
 	fn test_app_clipboard() -> Result<(), String> {
-		let copy_type = Selection::from_str("row1")?;
-		assert_eq!(Selection::TableRow(1), copy_type);
+		let copy_type = Selection::from_str("row1", true)?;
+		assert_eq!(Selection::Row1, copy_type);
 		assert_eq!(String::from("table row (1)"), copy_type.to_string());
-		let copy_type = Selection::from_str("key")?;
+		let copy_type = Selection::from_str("row2", true)?;
+		assert_eq!(Selection::Row2, copy_type);
+		assert_eq!(String::from("table row (2)"), copy_type.to_string());
+		let copy_type = Selection::from_str("key", true)?;
 		assert_eq!(Selection::Key, copy_type);
 		assert_eq!(String::from("exported key"), copy_type.to_string());
-		let copy_type = Selection::from_str("key_id")?;
+		let copy_type = Selection::from_str("key_id", true)?;
 		assert_eq!(Selection::KeyId, copy_type);
 		assert_eq!(String::from("key ID"), copy_type.to_string());
-		let copy_type = Selection::from_str("key_fingerprint")?;
+		let copy_type = Selection::from_str("key_fingerprint", true)?;
 		assert_eq!(Selection::KeyFingerprint, copy_type);
 		assert_eq!(String::from("key fingerprint"), copy_type.to_string());
-		let copy_type = Selection::from_str("key_user_id")?;
+		let copy_type = Selection::from_str("key_user_id", true)?;
 		assert_eq!(Selection::KeyUserId, copy_type);
 		assert_eq!(String::from("user ID"), copy_type.to_string());
 		Ok(())

--- a/src/app/style.rs
+++ b/src/app/style.rs
@@ -1,6 +1,5 @@
 use clap::ValueEnum;
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::str::FromStr;
 use tui::style::{Color, Style as TuiStyle};
 use tui::text::{Span, Spans, Text};
 
@@ -22,17 +21,6 @@ impl Default for Style {
 impl Display for Style {
 	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
 		write!(f, "{}", format!("{self:?}").to_lowercase())
-	}
-}
-
-impl FromStr for Style {
-	type Err = String;
-	fn from_str(style: &str) -> Result<Self, Self::Err> {
-		match style {
-			"plain" => Ok(Self::Plain),
-			"colored" => Ok(Self::Colored),
-			_ => Err(String::from("could not parse the style")),
-		}
 	}
 }
 

--- a/src/app/style.rs
+++ b/src/app/style.rs
@@ -1,10 +1,11 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
+use clap::ValueEnum;
 use tui::style::{Color, Style as TuiStyle};
 use tui::text::{Span, Spans, Text};
 
 /// Application style.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum Style {
 	/// Plain style with basic colors.
 	Plain,

--- a/src/app/style.rs
+++ b/src/app/style.rs
@@ -1,6 +1,6 @@
+use clap::ValueEnum;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
-use clap::ValueEnum;
 use tui::style::{Color, Style as TuiStyle};
 use tui::text::{Span, Spans, Text};
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -80,7 +80,6 @@ pub struct Args {
 	#[clap(
 		long,
 		value_name = "option",
-		value_parser = ["key_id", "key_fpr", "user_id", "row1", "row2"],
 		env
 	)]
 	pub select: Option<Selection>,

--- a/src/args.rs
+++ b/src/args.rs
@@ -6,7 +6,7 @@ use crate::app::style::Style;
 use crate::gpg::key::KeyDetail;
 use crate::widget::style::Color;
 use std::str::FromStr;
-use clap::{AppSettings, Parser};
+use clap::Parser;
 
 /// Argument parser powered by [`clap`].
 #[derive(Debug, Default, Parser)]
@@ -16,7 +16,6 @@ use clap::{AppSettings, Parser};
     author = env!("CARGO_PKG_AUTHORS"),
     about = env!("CARGO_PKG_DESCRIPTION"),
 	before_help = BANNERS[2],
-    global_setting = AppSettings::DeriveDisplayOrder,
 	rename_all_env = "screaming-snake",
 )]
 pub struct Args {
@@ -94,8 +93,7 @@ pub struct Args {
 		long,
 		value_name = "level",
 		default_value = "minimum",
-		env,
-		arg_enum
+		env
 	)]
 	pub detail_level: KeyDetail,
 	/// Enables the selection mode.
@@ -115,7 +113,7 @@ impl Args {
 	/// input string into contents of the path returned by [`home_dir`].
 	///
 	/// [`home_dir`]: dirs_next::home_dir
-	fn parse_dir(dir: &str) -> clap::Result<Option<String>> {
+	fn parse_dir(dir: &str) -> Result<Option<String>, String> {
 		Ok(Some(shellexpand::tilde(dir).to_string()))
 	}
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -6,7 +6,6 @@ use crate::app::style::Style;
 use crate::gpg::key::KeyDetail;
 use crate::widget::style::Color;
 use clap::Parser;
-use std::str::FromStr;
 
 /// Argument parser powered by [`clap`].
 #[derive(Debug, Default, Parser)]
@@ -71,7 +70,6 @@ pub struct Args {
 		long,
 		value_name = "color",
 		default_value = "gray",
-		value_parser = Color::from_str,
 		env
 	)]
 	pub color: Color,

--- a/src/args.rs
+++ b/src/args.rs
@@ -5,8 +5,8 @@ use crate::app::selection::Selection;
 use crate::app::style::Style;
 use crate::gpg::key::KeyDetail;
 use crate::widget::style::Color;
-use std::str::FromStr;
 use clap::Parser;
+use std::str::FromStr;
 
 /// Argument parser powered by [`clap`].
 #[derive(Debug, Default, Parser)]
@@ -89,12 +89,7 @@ pub struct Args {
 	#[clap(short, long, value_name = "app", default_value = "xplr", env)]
 	pub file_explorer: String,
 	/// Sets the detail level for the keys.
-	#[clap(
-		long,
-		value_name = "level",
-		default_value = "minimum",
-		env
-	)]
+	#[clap(long, value_name = "level", default_value = "minimum", env)]
 	pub detail_level: KeyDetail,
 	/// Enables the selection mode.
 	#[clap(

--- a/src/args.rs
+++ b/src/args.rs
@@ -80,7 +80,6 @@ pub struct Args {
 		short,
 		long,
 		value_name = "style",
-		value_parser = ["plain", "colored"],
 		default_value = "plain",
 		env
 	)]
@@ -108,8 +107,8 @@ impl Args {
 	/// input string into contents of the path returned by [`home_dir`].
 	///
 	/// [`home_dir`]: dirs_next::home_dir
-	fn parse_dir(dir: &str) -> Result<Option<String>, String> {
-		Ok(Some(shellexpand::tilde(dir).to_string()))
+	fn parse_dir(dir: &str) -> Result<String, String> {
+		Ok(shellexpand::tilde(dir).to_string())
 	}
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -77,11 +77,7 @@ pub struct Args {
 	#[clap(long, value_name = "level", default_value = "minimum", env)]
 	pub detail_level: KeyDetail,
 	/// Enables the selection mode.
-	#[clap(
-		long,
-		value_name = "option",
-		env
-	)]
+	#[clap(long, value_name = "option", env)]
 	pub select: Option<Selection>,
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -5,6 +5,7 @@ use crate::app::selection::Selection;
 use crate::app::style::Style;
 use crate::gpg::key::KeyDetail;
 use crate::widget::style::Color;
+use std::str::FromStr;
 use clap::{AppSettings, Parser};
 
 /// Argument parser powered by [`clap`].
@@ -30,7 +31,7 @@ pub struct Args {
 		long,
 		value_name = "path",
 		env = "GPG_TUI_CONFIG",
-		parse(from_str = Args::parse_dir)
+		value_parser = Args::parse_dir
 	)]
 	pub config: Option<String>,
 	/// Sets the GnuPG home directory.
@@ -38,7 +39,7 @@ pub struct Args {
 		long,
 		value_name = "dir",
 		env = "GNUPGHOME",
-		parse(from_str = Args::parse_dir)
+		value_parser = Args::parse_dir
 	)]
 	pub homedir: Option<String>,
 	/// Sets the output directory.
@@ -47,7 +48,7 @@ pub struct Args {
 		long,
 		value_name = "dir",
 		env,
-		parse(from_str = Args::parse_dir)
+		value_parser = Args::parse_dir
 	)]
 	pub outdir: Option<String>,
 	/// Sets the template for the output file name.
@@ -56,7 +57,7 @@ pub struct Args {
 		value_name = "path",
 		default_value = "{type}_{query}.{ext}",
 		env,
-		parse(from_str = Args::parse_dir)
+		value_parser = Args::parse_dir
 	)]
 	pub outfile: String,
 	/// Sets the default key to sign with.
@@ -71,7 +72,7 @@ pub struct Args {
 		long,
 		value_name = "color",
 		default_value = "gray",
-		parse(from_str),
+		value_parser = Color::from_str,
 		env
 	)]
 	pub color: Color,
@@ -80,7 +81,7 @@ pub struct Args {
 		short,
 		long,
 		value_name = "style",
-		possible_values = &["plain", "colored"],
+		value_parser = ["plain", "colored"],
 		default_value = "plain",
 		env
 	)]
@@ -101,7 +102,7 @@ pub struct Args {
 	#[clap(
 		long,
 		value_name = "option",
-		possible_values = &["key_id", "key_fpr", "user_id", "row1", "row2"],
+		value_parser = ["key_id", "key_fpr", "user_id", "row1", "row2"],
 		env
 	)]
 	pub select: Option<Selection>,
@@ -114,8 +115,8 @@ impl Args {
 	/// input string into contents of the path returned by [`home_dir`].
 	///
 	/// [`home_dir`]: dirs_next::home_dir
-	fn parse_dir(dir: &str) -> String {
-		shellexpand::tilde(dir).to_string()
+	fn parse_dir(dir: &str) -> clap::Result<Option<String>> {
+		Ok(Some(shellexpand::tilde(dir).to_string()))
 	}
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -65,22 +65,10 @@ pub struct Args {
 	#[clap(short, long, value_name = "ms", default_value = "250", env)]
 	pub tick_rate: u64,
 	/// Sets the accent color of the terminal.
-	#[clap(
-		short,
-		long,
-		value_name = "color",
-		default_value = "gray",
-		env
-	)]
+	#[clap(short, long, value_name = "color", default_value = "gray", env)]
 	pub color: Color,
 	/// Sets the style of the terminal.
-	#[clap(
-		short,
-		long,
-		value_name = "style",
-		default_value = "plain",
-		env
-	)]
+	#[clap(short, long, value_name = "style", default_value = "plain", env)]
 	pub style: Style,
 	/// Sets the utility for file selection.
 	#[clap(short, long, value_name = "app", default_value = "xplr", env)]

--- a/src/bin/completions.rs
+++ b/src/bin/completions.rs
@@ -1,4 +1,4 @@
-use clap::{ArgEnum, CommandFactory};
+use clap::{CommandFactory, ValueEnum};
 use clap_complete::Shell;
 use gpg_tui::args::Args;
 use std::env;

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::fs;
 use std::str::FromStr;
+use clap::ValueEnum;
 use toml::value::Value;
 
 /// Application configuration.
@@ -172,7 +173,7 @@ impl Config {
 		args.default_key = self.gpg.default_key.clone();
 		args.tick_rate = self.general.tick_rate;
 		args.color = Color::from(self.general.color.as_ref());
-		args.style = Style::from_str(&self.general.style).unwrap_or_default();
+		args.style = Style::from_str(&self.general.style, true).unwrap_or_default();
 		args.detail_level = self.general.detail_level.unwrap_or_default();
 		args.file_explorer = self.general.file_explorer.clone();
 		args

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,11 +6,11 @@ use crate::args::Args;
 use crate::gpg::key::KeyDetail;
 use crate::widget::style::Color;
 use anyhow::Result;
+use clap::ValueEnum;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::fs;
 use std::str::FromStr;
-use clap::ValueEnum;
 use toml::value::Value;
 
 /// Application configuration.
@@ -173,7 +173,8 @@ impl Config {
 		args.default_key = self.gpg.default_key.clone();
 		args.tick_rate = self.general.tick_rate;
 		args.color = Color::from(self.general.color.as_ref());
-		args.style = Style::from_str(&self.general.style, true).unwrap_or_default();
+		args.style =
+			Style::from_str(&self.general.style, true).unwrap_or_default();
 		args.detail_level = self.general.detail_level.unwrap_or_default();
 		args.file_explorer = self.general.file_explorer.clone();
 		args

--- a/src/gpg/key.rs
+++ b/src/gpg/key.rs
@@ -322,7 +322,7 @@ mod tests {
 		assert_eq!(KeyDetail::Standard, key.detail);
 		assert_eq!(
 			Ok(key.detail),
-			<KeyDetail as std::str::FromStr>::from_str("standard")
+			KeyDetail::from_str("standard", true)
 		);
 		key.detail.increase();
 		assert_eq!(KeyDetail::Full, key.detail);

--- a/src/gpg/key.rs
+++ b/src/gpg/key.rs
@@ -47,10 +47,13 @@ impl FromStr for KeyType {
 #[clap(rename_all = "snake_case")]
 pub enum KeyDetail {
 	/// Show only the primary key and user ID.
+	#[clap(aliases = ["min", "1"])]
 	Minimum = 0,
 	/// Show all subkeys and user IDs.
+	#[clap(alias = "2")]
 	Standard = 1,
 	/// Show signatures.
+	#[clap(alias = "3")]
 	Full = 2,
 }
 
@@ -66,17 +69,6 @@ impl Display for KeyDetail {
 	}
 }
 
-impl FromStr for KeyDetail {
-	type Err = ();
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		match s.to_lowercase().as_str() {
-			"1" | "min" | "minimum" => Ok(KeyDetail::Minimum),
-			"2" | "standard" => Ok(KeyDetail::Standard),
-			"3" | "full" => Ok(KeyDetail::Full),
-			_ => Err(()),
-		}
-	}
-}
 
 impl KeyDetail {
 	/// Increases the level of detail.

--- a/src/gpg/key.rs
+++ b/src/gpg/key.rs
@@ -1,5 +1,5 @@
 use crate::gpg::handler;
-use clap::ArgEnum;
+use clap::ValueEnum;
 use gpgme::{Key, SignatureNotation, Subkey, UserId, UserIdSignature};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Result as FmtResult};
@@ -41,7 +41,7 @@ impl FromStr for KeyType {
 
 /// Level of detail to show for key.
 #[derive(
-	Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, ArgEnum,
+	Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, ValueEnum,
 )]
 #[serde(rename_all = "snake_case")]
 #[clap(rename_all = "snake_case")]

--- a/src/gpg/key.rs
+++ b/src/gpg/key.rs
@@ -320,10 +320,7 @@ mod tests {
 		let key = &mut keys[0];
 		key.detail.increase();
 		assert_eq!(KeyDetail::Standard, key.detail);
-		assert_eq!(
-			Ok(key.detail),
-			KeyDetail::from_str("standard", true)
-		);
+		assert_eq!(Ok(key.detail), KeyDetail::from_str("standard", true));
 		key.detail.increase();
 		assert_eq!(KeyDetail::Full, key.detail);
 		assert_eq!("full", key.detail.to_string());

--- a/src/gpg/key.rs
+++ b/src/gpg/key.rs
@@ -69,7 +69,6 @@ impl Display for KeyDetail {
 	}
 }
 
-
 impl KeyDetail {
 	/// Increases the level of detail.
 	pub fn increase(&mut self) {

--- a/src/widget/style.rs
+++ b/src/widget/style.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use colorsys::Rgb;
 use tui::style::Color as TuiColor;
 
@@ -47,6 +48,13 @@ impl<'a> From<&'a str> for Color {
 				},
 			},
 		}
+	}
+}
+
+impl FromStr for Color {
+	type Err = std::convert::Infallible;
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(Self::from(s))
 	}
 }
 

--- a/src/widget/style.rs
+++ b/src/widget/style.rs
@@ -1,5 +1,5 @@
-use std::str::FromStr;
 use colorsys::Rgb;
+use std::str::FromStr;
 use tui::style::Color as TuiColor;
 
 /// Wrapper for widget colors.


### PR DESCRIPTION
## Description
Upgrade the `clap` crate version from `3.2.23` to `4.2.7` and the `clap_complete` crate version from `3.2.5` to `4.2.3` (the latest versions at this time).
> To make this work I had to make some weird* decisions (if we can say), like implementing the `FromStr` crate for the `Color` struct to use it as a custom parser for the colour option, and making the `parse_dir` return `Result<String, String>` instead of just return a `String` 'cause the `value_parser` attr require a function that returns a Result type. Am not sure if this is the best solution in the world to solve this problem, but it works :) 

## Motivation and Context
- Close #52 

## How Has This Been Tested?
- I ran the `cargo run -- --help`  command and  I saw the expected output
- I ran the all tests and they passed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).

