### PR TITLE
feat: Add panic hook for resetting the terminal

### DIFF
--- a/src/term/tui.rs
+++ b/src/term/tui.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use std::io;
+use std::panic;
 use std::sync::atomic::Ordering;
 use tui::backend::Backend;
 use tui::Terminal;
@@ -46,6 +47,14 @@ impl<B: Backend> Tui<B> {
 			EnterAlternateScreen,
 			EnableMouseCapture
 		)?;
+
+		let panic_hook = panic::take_hook();
+
+		panic::set_hook(Box::new(move |panic| {
+			Self::reset().expect("failed to reset the terminal");
+			panic_hook(panic);
+		}));
+
 		self.terminal.hide_cursor()?;
 		self.terminal.clear()?;
 		Ok(())
@@ -95,13 +104,19 @@ impl<B: Backend> Tui<B> {
 	///
 	/// It disables the raw mode and reverts back the terminal properties.
 	pub fn exit(&mut self) -> Result<()> {
+		Self::reset()?;
+		self.terminal.show_cursor()?;
+		Ok(())
+	}
+
+	fn reset() -> Result<()> {
 		terminal::disable_raw_mode()?;
 		crossterm::execute!(
-			io::stderr(),
+			io::stdout(),
 			LeaveAlternateScreen,
 			DisableMouseCapture
 		)?;
-		self.terminal.show_cursor()?;
+
 		Ok(())
 	}
 }

--- a/src/term/tui.rs
+++ b/src/term/tui.rs
@@ -47,14 +47,11 @@ impl<B: Backend> Tui<B> {
 			EnterAlternateScreen,
 			EnableMouseCapture
 		)?;
-
 		let panic_hook = panic::take_hook();
-
 		panic::set_hook(Box::new(move |panic| {
 			Self::reset().expect("failed to reset the terminal");
 			panic_hook(panic);
 		}));
-
 		self.terminal.hide_cursor()?;
 		self.terminal.clear()?;
 		Ok(())
@@ -109,6 +106,7 @@ impl<B: Backend> Tui<B> {
 		Ok(())
 	}
 
+	/// Resets the terminal interface.
 	fn reset() -> Result<()> {
 		terminal::disable_raw_mode()?;
 		crossterm::execute!(
@@ -116,7 +114,6 @@ impl<B: Backend> Tui<B> {
 			LeaveAlternateScreen,
 			DisableMouseCapture
 		)?;
-
 		Ok(())
 	}
 }

--- a/src/term/tui.rs
+++ b/src/term/tui.rs
@@ -112,7 +112,7 @@ impl<B: Backend> Tui<B> {
 	fn reset() -> Result<()> {
 		terminal::disable_raw_mode()?;
 		crossterm::execute!(
-			io::stdout(),
+			io::stderr(),
 			LeaveAlternateScreen,
 			DisableMouseCapture
 		)?;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added a panic hook following the [raratui implementation](https://github.com/ratatui-org/rust-tui-template/pull/13).
TL;DR When an unexpected error happens program exits alternate screen and disables raw mode instead of messing up the terminal.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #104 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I used cargo test

## Output (if appropriate):
<!--- What is the expected output of the project after these changes? -->
<!--- You might use logs, screenshots or files depending on the behaviour. --->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (Some test fail, but they failed before I made any changes)
