### PR TITLE
Add "rev" detail to default view of keys

### DIFF
--- a/src/app/style.rs
+++ b/src/app/style.rs
@@ -1,7 +1,10 @@
 use clap::ValueEnum;
+use core::panic;
 use ratatui::style::{Color, Style as TuiStyle};
 use ratatui::text::{Line, Span, Text};
 use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use crate::gpg::key;
 
 /// Application style.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
@@ -62,6 +65,7 @@ pub fn get_colored_table_row<'a>(
 			line.find('[').unwrap_or_default(),
 			line.find(']').unwrap_or_default(),
 		);
+
 		row.push(
 			// Colorize inside the brackets to start.
 			if second_bracket > first_bracket + 1 {
@@ -149,6 +153,114 @@ pub fn get_colored_table_row<'a>(
 						highlight_style,
 					));
 				// Colorize inside the arrows.
+				} else if let (
+					Some(first_parenthesis),
+					Some(second_parenthesis),
+				) = (data.rfind('('), data.rfind(')'))
+				{
+					let inner = line[first_parenthesis..].to_string();
+
+					log::trace!(target: "style", "inner: {inner:?}");
+
+					// panic!("{:?}", data);
+
+					let expected = [
+						// expired
+						String::from("exp"),
+						// revoked
+						String::from("rev"),
+						// disabled
+						String::from("d"),
+						// invalid
+						String::from("i"),
+					];
+
+					let matched: Vec<_> = data.match_indices("(").collect();
+					// panic!("{:?}", matched);
+
+					// let s = String::from("foo rev bar");
+					// let matched: Vec<_> = s.match_indices("(").collect();
+
+					// panic!(
+					// 	"Data: {:?}, Inner: {:?}, Contains? {:?}",
+					// 	&s,
+					// 	&inner,
+					// 	s.contains(&inner)
+					// );
+
+					if let Some((opening_parenthesis, char)) =
+						data.match_indices("(").next()
+					{
+						let inner = data[(opening_parenthesis + 1)
+							..(opening_parenthesis + 4)]
+							.to_string();
+
+						// THIS WORKS
+						// panic!(
+						// 	"Data: {:?}, Inner: {:?}, Contains? {:?}",
+						// 	&data,
+						// 	&inner,
+						// 	expected.contains(&inner)
+						// );
+
+						if [
+							// expired
+							String::from("exp"),
+							// revoked
+							String::from("rev"),
+							// disabled
+							String::from("d"),
+							// invalid
+							String::from("i"),
+						]
+						.contains(&inner)
+						{
+							colored_line.push(Span::styled(
+								data[..first_parenthesis].to_string(),
+								highlight_style,
+							));
+							colored_line.push(Span::styled(
+								"(",
+								TuiStyle::default().fg(Color::DarkGray),
+							));
+							colored_line.push(Span::styled(
+								data[first_parenthesis + 1..second_parenthesis]
+									.to_string(),
+								TuiStyle::default().fg(Color::Red),
+							));
+							colored_line.push(Span::styled(
+								")",
+								TuiStyle::default().fg(Color::DarkGray),
+							));
+							colored_line.push(Span::styled(
+								data[second_parenthesis + 1..].to_string(),
+								highlight_style,
+							));
+						}
+					}
+
+				// colored_line.push(Span::styled(
+				// 	data[..first_parenthesis].to_string(),
+				// 	highlight_style,
+				// ));
+				// colored_line.push(Span::styled(
+				// 	"{",
+				// 	TuiStyle::default().fg(Color::DarkGray),
+				// ));
+				// colored_line.push(Span::styled(
+				// 	data[first_parenthesis + 1..second_parenthesis]
+				// 		.to_string(),
+				// 	TuiStyle::default().fg(Color::Cyan),
+				// ));
+				// colored_line.push(Span::styled(
+				// 	"}",
+				// 	TuiStyle::default().fg(Color::DarkGray),
+				// ));
+				// colored_line.push(Span::styled(
+				// 	data[second_parenthesis + 1..].to_string(),
+				// 	highlight_style,
+				// ));
+				// FIXME
 				} else if let (Some(first_arrow), Some(second_arrow)) =
 					(data.rfind('<'), data.rfind('>'))
 				{

--- a/src/app/style.rs
+++ b/src/app/style.rs
@@ -153,6 +153,8 @@ pub fn get_colored_table_row<'a>(
 						highlight_style,
 					));
 				// Colorize inside the arrows.
+
+				// FIXME: These need updating for breakage
 				} else if let (
 					Some(first_parenthesis),
 					Some(second_parenthesis),


### PR DESCRIPTION
## Description
Brief POC wip to learn the internals and add "rev" detail to the top level view of keys

## Motivation and Context
This helps to quickly visualise what has and has not been revoked. Ideally I plan to add a default filtering option to hide revoked keys,

## How Has This Been Tested?
Manually, tests need updating.

## Output (if appropriate):
You should see `(rev)` at the top-level view of keys.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
Outstanding tasks:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
