### PR TITLE
refactor: replace format! with concat! for string literals

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -153,7 +153,7 @@ impl Config {
 	/// Returns the path if the configuration file is found.
 	pub fn get_default_location() -> Option<String> {
 		if let Some(config_dir) = dirs_next::config_dir() {
-			let file_name = format!("{}.toml", env!("CARGO_PKG_NAME"));
+			let file_name = concat!(env!("CARGO_PKG_NAME"), ".toml");
 			for config_file in [
 				config_dir.join(&file_name),
 				config_dir.join(env!("CARGO_PKG_NAME")).join(&file_name),
@@ -251,7 +251,7 @@ mod tests {
 	fn test_parse_config() -> Result<()> {
 		let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 			.join("config")
-			.join(format!("{}.toml", env!("CARGO_PKG_NAME")))
+			.join(concat!(env!("CARGO_PKG_NAME"), ".toml"))
 			.to_string_lossy()
 			.into_owned();
 		let mut config = Config::parse_config(&path)?;


### PR DESCRIPTION
## Description
- Replace `format!` with `concat!` for string literals

## Motivation and Context
- Although `format!` macro is very powerful, it introduces overhead of memory allocation on the heap compared to `&str`. Therefore, when `format!` macro is unnecessary, we should avoid using it.

## How Has This Been Tested?
- `cargo test` passed.

## Output (if appropriate):
<!--- What is the expected output of the project after these changes? -->
<!--- You might use logs, screenshots or files depending on the behaviour. --->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
