### PR TITLE
fix: improve error visibility across TUI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+# cargo-features = ["codegen-backend", "trim-paths"]
+
 [package]
 name = "gpg-tui"
 version = "0.11.2"
@@ -37,7 +39,9 @@ ratatui = "0.30.1"
 anyhow = "1.0.102"
 chrono = "0.4.45"
 unicode-width = "0.2.2"
-arboard = { version = "3.6.1", default-features = false, features = ["wayland-data-control"] }
+arboard = { version = "3.6.1", default-features = false, features = [
+  "wayland-data-control",
+] }
 colorsys = "0.7.3"
 shellexpand = "3.1.2"
 toml = "1.1.2"
@@ -71,8 +75,15 @@ pretty_assertions = "1.4.1"
 
 [profile.dev]
 opt-level = 0
-debug = true
-panic = "abort"
+debug = "full"
+panic = "abort"         # "unwind" | "abort"
+debug-assertions = true
+codegen-units = 256
+incremental = true
+overflow-checks = true
+strip = "none"          # true | false | "none" | "symbols" | "debuginfo" ## Leave off @ w. THIS IS NOT OBFUSCATION.
+lto = "off"             # "false" ### # true | false | "off" | "thin" | "fat" ## Can't use with cranelift yet
+# trim-paths = "none"
 
 [profile.test]
 opt-level = 0

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -192,16 +192,41 @@ impl Display for Command {
 }
 
 impl FromStr for Command {
-	type Err = ();
+	type Err = String;
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		let mut values = s
+		let values = s
 			.replacen(':', "", 1)
 			.to_lowercase()
 			.split_whitespace()
 			.map(String::from)
 			.collect::<Vec<String>>();
+		if values.is_empty() {
+			return Err(String::from("command string is empty"));
+		}
+		debug_assert!(!values.is_empty(), "command string is empty");
+		debug_assert_eq!(
+			values[0],
+			values[0].to_lowercase(),
+			"command is not lowercase"
+		);
 		let command = values.first().cloned().unwrap_or_default();
-		let args = values.drain(1..).collect::<Vec<String>>();
+		debug_assert!(!command.is_empty(), "command is empty");
+
+		let args = values.iter().skip(1).cloned().collect::<Vec<String>>();
+		if command.is_empty() {
+			return Err(String::from("command is empty"));
+		}
+
+		let arg = args.first().cloned().unwrap_or_default();
+
+		#[rustfmt::skip]
+		let arg_or_fallback = |fallback: &str| -> Result<String, String> {
+			if arg.is_empty() && !fallback.is_empty() {
+				Ok(fallback.to_string())
+			} else if arg.is_empty() && fallback.is_empty() {
+				Err(String::from("argument is missing"))
+			} else { Ok(arg.clone()) } };
+
 		match command.as_str() {
 			"confirm" => Ok(Command::Confirm(Box::new(if args.is_empty() {
 				Command::None
@@ -210,28 +235,27 @@ impl FromStr for Command {
 			}))),
 			"help" | "h" => Ok(Command::ShowHelp),
 			"style" => Ok(Command::ChangeStyle(
-				Style::from_str(
-					&args.first().cloned().unwrap_or_default(),
-					true,
-				)
-				.unwrap_or_default(),
+				Style::from_str(&arg, true).unwrap_or_default(),
 			)),
 			"output" | "out" => {
 				if !args.is_empty() {
 					Ok(Command::ShowOutput(
-						OutputType::from(
-							args.first().cloned().unwrap_or_default(),
-						),
+						OutputType::from_str(&arg).unwrap_or_default(),
 						args[1..].join(" "),
 					))
 				} else {
-					Err(())
+					Err(String::from("output type is missing"))
 				}
 			}
 			"options" | "opt" => Ok(Command::ShowOptions),
-			"list" | "ls" => Ok(Command::ListKeys(KeyType::from_str(
-				&args.first().cloned().unwrap_or_else(|| String::from("pub")),
-			)?)),
+			"list" | "ls" => Ok(Command::ListKeys(
+				KeyType::from_str(
+					&arg_or_fallback("pub")?, // 'is_empty()' when unwrap_or_default() was used above the match statemnt
+				)
+				.map_err(|_| {
+					String::from("invalid key type :: [list] | [ls]")
+				})?,
+			)),
 			"import" | "receive" => Ok(Command::ImportKeys(
 				s.replacen(':', "", 1)
 					.split_whitespace()
@@ -253,11 +277,10 @@ impl FromStr for Command {
 					patterns.truncate(patterns.len() - 1)
 				}
 				Ok(Command::ExportKeys(
-					KeyType::from_str(
-						&args
-							.first()
-							.cloned()
-							.unwrap_or_else(|| String::from("pub")),
+					KeyType::from_str(&arg_or_fallback("pub")?).map_err(
+						|_| {
+							String::from("invalid key type :: [export] | [exp]")
+						},
 					)?,
 					patterns,
 					export_subkeys,
@@ -266,12 +289,7 @@ impl FromStr for Command {
 			"delete" | "del" => {
 				let key_id = args.get(1).cloned().unwrap_or_default();
 				Ok(Command::DeleteKey(
-					KeyType::from_str(
-						&args
-							.first()
-							.cloned()
-							.unwrap_or_else(|| String::from("pub")),
-					)?,
+					KeyType::from_str(&arg_or_fallback("pub")?)?,
 					if let Some(key) = key_id.strip_prefix("0x") {
 						format!("0x{}", key.to_string().to_uppercase())
 					} else {
@@ -279,15 +297,19 @@ impl FromStr for Command {
 					},
 				))
 			}
-			"send" => Ok(Command::SendKey(args.first().cloned().ok_or(())?)),
-			"edit" => Ok(Command::EditKey(args.first().cloned().ok_or(())?)),
-			"sign" => Ok(Command::SignKey(args.first().cloned().ok_or(())?)),
+			#[rustfmt::skip]
+			"send" => Ok(Command::SendKey(args.first().cloned().expect("Invalid"))),
+			#[rustfmt::skip]
+			"edit" => Ok(Command::EditKey(args.first().cloned().expect("Invalid"))),
+			#[rustfmt::skip]
+			"sign" => Ok(Command::SignKey(args.first().cloned().expect("Invalid"))),
+			#[rustfmt::skip]
 			"generate" | "gen" => Ok(Command::GenerateKey),
 			"copy" | "c" => {
 				if let Some(arg) = args.first().cloned() {
-					Ok(Command::Copy(
-						Selection::from_str(&arg, true).map_err(|_| ())?,
-					))
+					Ok(Command::Copy(Selection::from_str(&arg, true).map_err(
+						|_| String::from("invalid key type :: [copy] | [c]"),
+					)?))
 				} else {
 					Ok(Command::SwitchMode(Mode::Copy))
 				}
@@ -320,9 +342,22 @@ impl FromStr for Command {
 			"get" | "g" => {
 				Ok(Command::Get(args.first().cloned().unwrap_or_default()))
 			}
-			"mode" | "m" => Ok(Command::SwitchMode(Mode::from_str(
-				&args.first().cloned().ok_or(())?,
-			)?)),
+			"mode" | "m" => {
+				// Ok(Command::SwitchMode(Mode::from_str(&args.first().cloned())?))
+				let args = arg_or_fallback("").map_err(|_| {
+					String::from("mode is missing :: [mode] | [m]")
+				})?;
+
+				if let Ok(mode) = match Mode::from_str(&args) {
+					Ok(mode) => Ok(mode),
+					Err(_) => Err(String::from("invalid mode :: [mode] | [m]")),
+				} {
+					Ok(Command::SwitchMode(mode))
+				} else {
+					Err(String::from("invalid mode :: [mode] | [m]"))
+				}
+			}
+
 			"normal" | "n" => Ok(Command::SwitchMode(Mode::Normal)),
 			"visual" | "v" => Ok(Command::SwitchMode(Mode::Visual)),
 			"paste" | "p" => Ok(Command::Paste),
@@ -331,7 +366,7 @@ impl FromStr for Command {
 			"next" => Ok(Command::NextTab),
 			"previous" | "prev" => Ok(Command::PreviousTab),
 			"refresh" | "r" => {
-				if args.first() == Some(&String::from("keys")) {
+				if args.first().cloned() == Some(String::from("keys")) {
 					Ok(Command::RefreshKeys)
 				} else {
 					Ok(Command::Refresh)
@@ -340,7 +375,7 @@ impl FromStr for Command {
 			"quit" | "q" | "q!" => Ok(Command::Quit),
 			"logs" | "l" => Ok(Command::Logs),
 			"none" => Ok(Command::None),
-			_ => Err(()),
+			_ => Err(format!("invalid command: {command}")),
 		}
 	}
 }
@@ -350,7 +385,7 @@ mod tests {
 	use super::*;
 	use pretty_assertions::assert_eq;
 	#[test]
-	fn test_app_command() -> Result<(), ()> {
+	fn test_app_command() -> Result<(), String> {
 		assert_eq!(
 			Command::Confirm(Box::new(Command::None)),
 			Command::from_str(":confirm none")?

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -219,13 +219,15 @@ impl FromStr for Command {
 
 		let arg = args.first().cloned().unwrap_or_default();
 
-		#[rustfmt::skip]
 		let arg_or_fallback = |fallback: &str| -> Result<String, String> {
 			if arg.is_empty() && !fallback.is_empty() {
 				Ok(fallback.to_string())
 			} else if arg.is_empty() && fallback.is_empty() {
 				Err(String::from("argument is missing"))
-			} else { Ok(arg.clone()) } };
+			} else {
+				Ok(arg.clone())
+			}
+		};
 
 		match command.as_str() {
 			"confirm" => Ok(Command::Confirm(Box::new(if args.is_empty() {
@@ -297,13 +299,15 @@ impl FromStr for Command {
 					},
 				))
 			}
-			#[rustfmt::skip]
-			"send" => Ok(Command::SendKey(args.first().cloned().expect("Invalid"))),
-			#[rustfmt::skip]
-			"edit" => Ok(Command::EditKey(args.first().cloned().expect("Invalid"))),
-			#[rustfmt::skip]
-			"sign" => Ok(Command::SignKey(args.first().cloned().expect("Invalid"))),
-			#[rustfmt::skip]
+			"send" => {
+				Ok(Command::SendKey(args.first().cloned().expect("Invalid")))
+			}
+			"edit" => {
+				Ok(Command::EditKey(args.first().cloned().expect("Invalid")))
+			}
+			"sign" => {
+				Ok(Command::SignKey(args.first().cloned().expect("Invalid")))
+			}
 			"generate" | "gen" => Ok(Command::GenerateKey),
 			"copy" | "c" => {
 				if let Some(arg) = args.first().cloned() {

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -21,13 +21,13 @@ impl Display for Mode {
 }
 
 impl FromStr for Mode {
-	type Err = ();
+	type Err = String;
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		match s.to_lowercase().as_str() {
 			"normal" | "n" => Ok(Self::Normal),
 			"visual" | "v" => Ok(Self::Visual),
 			"copy" | "c" => Ok(Self::Copy),
-			_ => Err(()),
+			_ => Err(format!("invalid mode: {s}")),
 		}
 	}
 }
@@ -37,7 +37,7 @@ mod tests {
 	use super::*;
 	use pretty_assertions::assert_eq;
 	#[test]
-	fn test_app_mode() -> Result<(), ()> {
+	fn test_app_mode() -> Result<(), String> {
 		let mode = Mode::from_str("normal")?;
 		assert_eq!(Mode::Normal, mode);
 		assert_eq!(String::from("-- normal --"), mode.to_string());

--- a/src/app/prompt.rs
+++ b/src/app/prompt.rs
@@ -3,6 +3,7 @@ use log::Level;
 use crate::app::command::Command;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::str::FromStr;
 use std::time::Instant;
 
 /// Prefix character for indicating command input.
@@ -38,6 +39,26 @@ impl Display for OutputType {
 				_ => "",
 			}
 		)
+	}
+}
+
+impl FromStr for OutputType {
+	type Err = String;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(match s.to_lowercase().as_str() {
+			"success" => Self::Success,
+			"warning" => Self::Warning,
+			"failure" => Self::Failure,
+			"action" => Self::Action,
+			_ => Self::None,
+		})
+	}
+}
+
+impl From<OutputType> for String {
+	fn from(output_type: OutputType) -> Self {
+		output_type.to_string()
 	}
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,6 @@ use anyhow::Result;
 use clap::ValueEnum;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use serde::{de, Deserialize, Deserializer, Serialize};
-use std::fs;
 use std::str::FromStr;
 use toml::value::Value;
 
@@ -72,8 +71,23 @@ where
 	D: Deserializer<'de>,
 {
 	let mut key_bindings = Vec::new();
-	let keys: Vec<Value> = Deserialize::deserialize(deserializer)?;
+	let keys: Vec<Value> = Deserialize::deserialize(deserializer)
+		.map_err(|_| de::Error::custom("expected an array of strings"))?;
+
+	if keys.is_empty() {
+		return Err(de::Error::custom(
+			"The 'keys' component of the keys array cannot be empty",
+		));
+	}
+
 	for key in keys {
+		if !key.is_str() || !key.is_human_readable() {
+			// NOTE: Worth noting it's _could_ be viable here to `continue;` ?
+			return Err(de::Error::custom(
+				"each key binding must be a human-readable string",
+			));
+		}
+
 		if let Some(key_str) = key.as_str() {
 			let mut modifiers = KeyModifiers::NONE;
 			// parse a single character
@@ -123,7 +137,12 @@ fn deserialize_command<'de, D>(deserializer: D) -> Result<Command, D::Error>
 where
 	D: Deserializer<'de>,
 {
-	let s = String::deserialize(deserializer)?;
+	let s = String::deserialize(deserializer).unwrap_or_else(|_| String::new());
+	if s.is_empty() {
+		return Err(de::Error::custom(
+			"The 'command' component of the keys array cannot be empty",
+		));
+	}
 	Command::from_str(&s)
 		.map_err(|_| de::Error::custom(format!("invalid command ({s})")))
 }
@@ -169,8 +188,12 @@ impl Config {
 
 	/// Parses the configuration file.
 	pub fn parse_config(file: &str) -> Result<Config> {
-		let contents = fs::read_to_string(file)?;
-		let config: Config = toml::from_str(&contents)?;
+		let contents =
+			std::fs::read_to_string(file).expect("failed to read config file");
+		let config: Config = toml::from_str(&contents).map_err(|err| {
+			anyhow::anyhow!("failed to parse config file: {err}")
+		})?;
+
 		Ok(config)
 	}
 

--- a/src/gpg/key.rs
+++ b/src/gpg/key.rs
@@ -28,14 +28,14 @@ impl Display for KeyType {
 }
 
 impl FromStr for KeyType {
-	type Err = ();
+	type Err = String;
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		for key_type in &[Self::Public, Self::Secret] {
 			if key_type.to_string().matches(&s).count() >= 1 {
 				return Ok(*key_type);
 			}
 		}
-		Err(())
+		Err(format!("invalid key type: {s}"))
 	}
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,24 +21,28 @@ fn main() -> Result<()> {
 	// Parse command-line arguments.
 	let mut args = Args::parse();
 	// Initialize logger.
-	#[rustfmt::skip]
 	let log_level = if let Ok(log_level) = env::var("RUST_LOG") {
 		LevelFilter::from_str(&log_level)?
-	} else { LevelFilter::Trace };
+	} else {
+		LevelFilter::Trace
+	};
 
 	tui_logger::init_logger(log_level)?;
 	tui_logger::set_default_level(LevelFilter::Trace);
 
 	// Parse configuration file.
-	#[rustfmt::skip]
-	let config = if let Some(config_file) = args.config.to_owned().or_else(Config::get_default_location) {
+	let config = if let Some(config_file) =
+		args.config.to_owned().or_else(Config::get_default_location)
+	{
 		let config = Config::parse_config(&config_file).unwrap_or_else(|err| {
 			eprintln!("Failed to parse config file: {err}");
 			std::process::exit(2);
 		});
 		args = config.update_args(args);
 		config
-	} else { Config::default() };
+	} else {
+		Config::default()
+	};
 
 	if let Some(ref log_file) = args.log_file {
 		let file_options = TuiLoggerFile::new(log_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,29 +20,33 @@ use tui_logger::TuiLoggerFile;
 fn main() -> Result<()> {
 	// Parse command-line arguments.
 	let mut args = Args::parse();
+	// Initialize logger.
+	#[rustfmt::skip]
+	let log_level = if let Ok(log_level) = env::var("RUST_LOG") {
+		LevelFilter::from_str(&log_level)?
+	} else { LevelFilter::Trace };
+
+	tui_logger::init_logger(log_level)?;
+	tui_logger::set_default_level(LevelFilter::Trace);
+
 	// Parse configuration file.
-	let config = if let Some(config_file) =
-		args.config.to_owned().or_else(Config::get_default_location)
-	{
-		let config = Config::parse_config(&config_file)?;
+	#[rustfmt::skip]
+	let config = if let Some(config_file) = args.config.to_owned().or_else(Config::get_default_location) {
+		let config = Config::parse_config(&config_file).unwrap_or_else(|err| {
+			eprintln!("Failed to parse config file: {err}");
+			std::process::exit(2);
+		});
 		args = config.update_args(args);
 		config
-	} else {
-		Config::default()
-	};
-	// Initialize logger.
-	tui_logger::init_logger(if let Ok(log_level) = env::var("RUST_LOG") {
-		LevelFilter::from_str(&log_level)?
-	} else {
-		LevelFilter::Trace
-	})?;
-	tui_logger::set_default_level(LevelFilter::Trace);
+	} else { Config::default() };
+
 	if let Some(ref log_file) = args.log_file {
 		let file_options = TuiLoggerFile::new(log_file);
 		tui_logger::set_log_file(file_options);
 	}
 	log::debug!(target: "args", "{:?}", args);
 	log::debug!(target: "config", "{:?}", config);
+
 	// Set custom key bindings.
 	let custom_key_bindings = config
 		.general

--- a/src/widget/row.rs
+++ b/src/widget/row.rs
@@ -19,7 +19,7 @@ pub enum ScrollDirection {
 }
 
 impl FromStr for ScrollDirection {
-	type Err = ();
+	type Err = String;
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		let s = s.split_whitespace().collect::<Vec<&str>>();
 		let value = s.get(1).cloned().unwrap_or_default().parse().unwrap_or(1);
@@ -30,7 +30,7 @@ impl FromStr for ScrollDirection {
 			Some("left") | Some("l") => Ok(Self::Left(value)),
 			Some("top") | Some("t") => Ok(Self::Top),
 			Some("bottom") | Some("b") => Ok(Self::Bottom),
-			_ => Err(()),
+			_ => Err(format!("invalid scroll direction: {s:?}")),
 		}
 	}
 }
@@ -179,7 +179,7 @@ mod tests {
 	use super::*;
 	use pretty_assertions::assert_eq;
 	#[test]
-	fn test_widget_row() -> Result<(), ()> {
+	fn test_widget_row() -> Result<(), String> {
 		assert_eq!(
 			vec!["..", ".ne3", ".ne4", ".."],
 			RowItem::new(


### PR DESCRIPTION
## Summary

Found a bug where setting a `key_bindings` `command` to an empty string would just... crash, with the cited failure coming from the std lib's index - investigating it found that you're swallowing a LOT of errors when the program itself can't function if the return value is in an invalid state.
The changes rework some areas of error handling so the TUI actually shows what went wrong instead of swallowing failures silently.

## Changes
- Uses `type Error = String;` instead of `type Error = ();` in From/FromStr impl. to actually show what went wrong.
- Command now actually bubbles Errors instead of randomly swallowing them.
- Adds context to failure paths so errors surface with actionable info.
- Cleans up mode/state transitions that were hiding error states
- Additional checks (bounds and content etc.) on keys and commands at initial parsing.

- Tests also fixed up to accommodate changes to return values. (All passing).
